### PR TITLE
Remove codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,5 +4,4 @@
 # most precedence.
 
 # Primary repo maintainers
-* @liamsi
 ethereum/solidity/ @adlerjohn


### PR DESCRIPTION
The large parts of the orchestrator are being moved out of this repo soon anyways.