### PR TITLE
chore: Remove redundant ABIEncoderV2 pragmas.

### DIFF
--- a/ethereum/solidity/src/lib/tree/Constants.sol
+++ b/ethereum/solidity/src/lib/tree/Constants.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
-pragma experimental ABIEncoderV2;
 
 library Constants {
     ///////////////

--- a/ethereum/solidity/src/lib/tree/Utils.sol
+++ b/ethereum/solidity/src/lib/tree/Utils.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
-pragma experimental ABIEncoderV2;
 
 import "./Constants.sol";
 


### PR DESCRIPTION
Redundant with Solidity 0.8.x