### PR TITLE
Remove lint badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/celestiaorg/quantum-gravity-bridge?style=flat-square)](https://goreportcard.com/report/github.com/celestiaorg/quantum-gravity-bridge)
 [![Version](https://img.shields.io/github/tag/celestiaorg/quantum-gravity-bridge.svg?style=flat-square)](https://github.com/celestiaorg/quantum-gravity-bridge/releases/latest)
 [![License: Apache-2.0](https://img.shields.io/github/license/celestiaorg/quantum-gravity-bridge.svg?style=flat-square)](https://github.com/celestiaorg/quantum-gravity-bridge/blob/main/LICENSE)
-[![GitHub Super-Linter](https://img.shields.io/github/workflow/status/celestiaorg/quantum-gravity-bridge/Lint?style=flat-square&label=Lint)](https://github.com/marketplace/actions/super-linter)
 
 The Quantum Gravity Bridge (QGB) is a Celestia -> EVM message relay.
 It is based on Umee's Gravity Bridge implementation, [Peggo](https://github.com/umee-network/peggo).


### PR DESCRIPTION
## Description
Currently the README has a lint badge. AFAICT https://github.com/marketplace/actions/super-linter isn't enabled on this repo. See https://github.com/celestiaorg/quantum-gravity-bridge/tree/master/.github/workflows

## Screenshot (removes this badge)
<img width="95" alt="Screen Shot 2022-08-22 at 6 16 09 PM" src="https://user-images.githubusercontent.com/3699047/186028523-e90abf0a-14eb-4f9c-b615-e51378dedfd1.png">


