### PR TITLE
Remove extra keys from mergify config

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -7,8 +7,6 @@ pull_request_rules:
     actions:
       merge:
         method: squash
-        strict: true
-        commit_message: title+body
   - name: Backport patches to release/v0.1.x branch
     conditions:
       - base=master


### PR DESCRIPTION
## Description
This is an attempt to fix: https://github.com/celestiaorg/quantum-gravity-bridge/pull/124/checks?check_run_id=7962233579

`strict` and `commit_message` aren't supported keys for `actions.merge` (ref https://docs.mergify.com/actions/merge/).
It looks possible to use `commit_message_template` to achieve something similar to the previous `commit_message` config if desired.