### PR TITLE
Update foundry manifest file to work with new version.

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,2 +1,2 @@
-[default]
+[profile.default]
 solc_version = "0.8.11"


### PR DESCRIPTION
Fixes

> ``warning: Unknown section [default] found in foundry.toml. This notation for profiles has been deprecated and may result in the profile not being registered in future versions. Please use [profile.default] instead or run `forge config --fix`.``

from a newer version of Foundry.