### PR TITLE
Fix NMT leaf hash computation.

### DIFF
--- a/src/lib/tree/namespace/TreeHasher.sol
+++ b/src/lib/tree/namespace/TreeHasher.sol
@@ -30,7 +30,7 @@ function namespaceMax(bytes8 l, bytes8 r) pure returns (bytes8) {
 /// @dev More details in https://github.com/celestiaorg/celestia-specs/blob/master/src/specs/data_structures.md#namespace-merkle-tree
 // solhint-disable-next-line func-visibility
 function leafDigest(bytes8 minmaxNID, bytes memory data) pure returns (NamespaceNode memory) {
-    bytes32 digest = sha256(abi.encodePacked(Constants.LEAF_PREFIX, minmaxNID, minmaxNID, data));
+    bytes32 digest = sha256(abi.encodePacked(Constants.LEAF_PREFIX, minmaxNID, data));
     NamespaceNode memory node = NamespaceNode(minmaxNID, minmaxNID, digest);
     return node;
 }

--- a/src/lib/tree/namespace/test/NamespaceMerkleTree.t.sol
+++ b/src/lib/tree/namespace/test/NamespaceMerkleTree.t.sol
@@ -21,27 +21,27 @@ Data blocks: namespace id, data
 0xffffffffffffffff 0x08
 
 Leaf nodes: min namespace, max namespace, data
-0x0000000000000010 0x0000000000000010 0xcb9b006518aa5b6e8f62dcda719f42a17033573e2cde97fe2748944f81638514
-0x0000000000000020 0x0000000000000020 0xf4653e02dfeff8eddbcf1c7230dfea1dd45b7bcc2fb1ce6d04c33f2229e10f6b
-0x0000000000000030 0x0000000000000030 0x1f7e7711dd732649f2599fa0a47330c48ad64e460c1fb1287ba531797702e5fd
-0x0000000000000040 0x0000000000000040 0x32706b95e3c3e7b4dd285fd4f73ad33dfb2d37e2dd11b3e355749d218ec2e00d
-0xffffffffffffffff 0xffffffffffffffff 0x41206f8a19e9497538158cee344eae117bb0a7ba396561c4e1c3b245fced4f7f
-0xffffffffffffffff 0xffffffffffffffff 0x84dd5d21f95db8c01adb5c742191da892b01eaafe8dafc6b19a560331e5d5912
-0xffffffffffffffff 0xffffffffffffffff 0x24ddc56b10cebbf760b3a744ad3a0e91093db34b4d22995f6de6dac918e38ae5
-0xffffffffffffffff 0xffffffffffffffff 0xf5a80844a112828c28da280019cb6e97765f81e1e003cc78a198901494db2641
+0x0000000000000010 0x0000000000000010 0x531d57c729081d903721f7584b2fa031c8308918779e47d9ef68991b7a30eadf
+0x0000000000000020 0x0000000000000020 0xd3e46dc7795fef402ede7504a037e43af169f19b76cbdb2c7abb12252b6b2ecc
+0x0000000000000030 0x0000000000000030 0x78c554db7e421f683df27a171146ca2aa4659e1ec01e6c61fc7291b28f8da6dd
+0x0000000000000040 0x0000000000000040 0xa8bcefebd33001489fc678d3891c6fe71ce7ec0b5cbd2fc37fb5178c41a23ac3
+0xffffffffffffffff 0xffffffffffffffff 0x19628f21c9871b13b730e4f0c3f1eb0a033e5ea36e2d928e5580dce8276f3a1f
+0xffffffffffffffff 0xffffffffffffffff 0x2041097752c4838ed7649383808636798c3bbd9dcb7c70054a833536eca57509
+0xffffffffffffffff 0xffffffffffffffff 0x6d9dfdf16675fe8a327bbf048a8496686ceb1444268965477c00a73720ec743a
+0xffffffffffffffff 0xffffffffffffffff 0x22efe732017c70f7ef831b3c0b841d11fdf2230cfabf178d9560e0e4beb5adcd
 
 Inner nodes(depth = 2): min namespace, max namespace, data
-0x0000000000000010 0x0000000000000020 0xe0a6f55a5c2d86e0057b89d79bf5c6c3fdc5a40061566c39e93077556e2e3482
-0x0000000000000030 0x0000000000000040 0x3f8ded56b6a8d4e1e36832e8be93234e2e3a18c1a42edfb505ecc09f0039a10f
-0xffffffffffffffff 0xffffffffffffffff 0x61d6762ff063c2008a412246bc6bb370885c4e1a935ca28ed8699dc5c68ff28a
-0xffffffffffffffff 0xffffffffffffffff 0x9086b06cbc327959e3c34546aadc886300aff3e5c8f96a328267abf64ca5d25b
+0x0000000000000010 0x0000000000000020 0x8985f8bdc931cbae27e6ce4851ffe91f30f3c5c54c785aa9beac6e1b8494e63c
+0x0000000000000030 0x0000000000000040 0xbbd409114c569aa80cbc35146b183ac85f6e218f6345d59b7f6822ae440a7f9c
+0xffffffffffffffff 0xffffffffffffffff 0xf11ca80de48fa801927a8061e234a29b8ab63b8239a9ea1efecf92688999602d
+0xffffffffffffffff 0xffffffffffffffff 0xca4e971ee703d46a64ff78d8abf98618e79ce7d3c95e08f41806d3fb96c2bf0a
 
 Inner nodes(depth = 1): min namespace, max namespace, data
-0x0000000000000010 0x0000000000000040 0xed6a82bfecd113f693065e3b1f271f21150b6d793917402f6c05a01feb6b3eb8
-0xffffffffffffffff 0xffffffffffffffff 0x27209d167edf7ea1463f462b850471ce31b124b0b3405c33f9c39e692c9170da
+0x0000000000000010 0x0000000000000040 0x31cb53b761143d0a1b6b7f096b64c6c0543266fda00654070a2d485d0a66b281
+0xffffffffffffffff 0xffffffffffffffff 0xb3da10c55a205c40528dd8a65e5be607e8a08d5a02198fdd6407419ae3c373c9
 
 Root node: min namespace, max namespace, data
-0x0000000000000010 0x0000000000000040 0x16c760661bc5ed683d27dc2f045a81a67e837928527e0de209a195b6db60f462
+0x0000000000000010 0x0000000000000040 0x135fc2adb4f8569783f67b463d2245d95ea98046523a02ce015edaa292a92085
 **/
 
 contract NamespaceMerkleTreeTest is DSTest {
@@ -70,7 +70,7 @@ contract NamespaceMerkleTreeTest is DSTest {
         NamespaceNode memory root = NamespaceNode(
             nid,
             nid,
-            0x0a88111852095cae045340ea1f0b279944b2a756a213d9b50107d7489771e159
+            0x3e7077fd2f66d689e0cee6a7cf5b37bf2dca7c979af356d0a31cbc5c85605c7d
         );
         NamespaceNode[] memory sideNodes;
         uint256 key = 0;
@@ -86,7 +86,7 @@ contract NamespaceMerkleTreeTest is DSTest {
         NamespaceNode memory root = NamespaceNode(
             nid,
             nid,
-            0xf76ffbe4c6c748d1f68b8e694e2ae675c6507bfdad72d9a6d684d2d38a52f473
+            0xaa96931c3a623dc18aa70c476c74ef95fc8a828c5c0d664f5f64963a2f02be13
         );
         NamespaceNode[] memory sideNodes;
         uint256 key = 0;
@@ -102,7 +102,7 @@ contract NamespaceMerkleTreeTest is DSTest {
         NamespaceNode memory root = NamespaceNode(
             nid,
             nid,
-            0xc59fa9c4ec515726c2b342544433f844c7b930cf7a5e7abab593332453ceaf70
+            0x52807a4607ea5debf0b7d4ccb452f4af03e16b06a8e0aa0dfe177db1ff02123d
         );
         NamespaceNode[] memory sideNodes;
         uint256 key = 0;
@@ -117,13 +117,13 @@ contract NamespaceMerkleTreeTest is DSTest {
         NamespaceNode memory root = NamespaceNode(
             0x0000000000000010,
             0x0000000000000020,
-            0xe0a6f55a5c2d86e0057b89d79bf5c6c3fdc5a40061566c39e93077556e2e3482
+            0x8985f8bdc931cbae27e6ce4851ffe91f30f3c5c54c785aa9beac6e1b8494e63c
         );
         NamespaceNode[] memory sideNodes = new NamespaceNode[](1);
         sideNodes[0] = NamespaceNode(
             0x0000000000000020,
             0x0000000000000020,
-            0xf4653e02dfeff8eddbcf1c7230dfea1dd45b7bcc2fb1ce6d04c33f2229e10f6b
+            0xd3e46dc7795fef402ede7504a037e43af169f19b76cbdb2c7abb12252b6b2ecc
         );
 
         uint256 key = 0;
@@ -138,18 +138,18 @@ contract NamespaceMerkleTreeTest is DSTest {
         NamespaceNode memory root = NamespaceNode(
             0x0000000000000010,
             0x0000000000000040,
-            0xed6a82bfecd113f693065e3b1f271f21150b6d793917402f6c05a01feb6b3eb8
+            0x31cb53b761143d0a1b6b7f096b64c6c0543266fda00654070a2d485d0a66b281
         );
         NamespaceNode[] memory sideNodes = new NamespaceNode[](2);
         sideNodes[0] = NamespaceNode(
             0x0000000000000020,
             0x0000000000000020,
-            0xf4653e02dfeff8eddbcf1c7230dfea1dd45b7bcc2fb1ce6d04c33f2229e10f6b
+            0xd3e46dc7795fef402ede7504a037e43af169f19b76cbdb2c7abb12252b6b2ecc
         );
         sideNodes[1] = NamespaceNode(
             0x0000000000000030,
             0x0000000000000040,
-            0x3f8ded56b6a8d4e1e36832e8be93234e2e3a18c1a42edfb505ecc09f0039a10f
+            0xbbd409114c569aa80cbc35146b183ac85f6e218f6345d59b7f6822ae440a7f9c
         );
 
         uint256 key = 0;
@@ -164,23 +164,23 @@ contract NamespaceMerkleTreeTest is DSTest {
         NamespaceNode memory root = NamespaceNode(
             0x0000000000000010,
             0x0000000000000040,
-            0x16c760661bc5ed683d27dc2f045a81a67e837928527e0de209a195b6db60f462
+            0x135fc2adb4f8569783f67b463d2245d95ea98046523a02ce015edaa292a92085
         );
         NamespaceNode[] memory sideNodes = new NamespaceNode[](3);
         sideNodes[0] = NamespaceNode(
             0x0000000000000020,
             0x0000000000000020,
-            0xf4653e02dfeff8eddbcf1c7230dfea1dd45b7bcc2fb1ce6d04c33f2229e10f6b
+            0xd3e46dc7795fef402ede7504a037e43af169f19b76cbdb2c7abb12252b6b2ecc
         );
         sideNodes[1] = NamespaceNode(
             0x0000000000000030,
             0x0000000000000040,
-            0x3f8ded56b6a8d4e1e36832e8be93234e2e3a18c1a42edfb505ecc09f0039a10f
+            0xbbd409114c569aa80cbc35146b183ac85f6e218f6345d59b7f6822ae440a7f9c
         );
         sideNodes[2] = NamespaceNode(
             Constants.PARITY_SHARE_NAMESPACE_ID,
             Constants.PARITY_SHARE_NAMESPACE_ID,
-            0x27209d167edf7ea1463f462b850471ce31b124b0b3405c33f9c39e692c9170da
+            0xb3da10c55a205c40528dd8a65e5be607e8a08d5a02198fdd6407419ae3c373c9
         );
 
         uint256 key = 0;
@@ -195,23 +195,23 @@ contract NamespaceMerkleTreeTest is DSTest {
         NamespaceNode memory root = NamespaceNode(
             0x0000000000000010,
             0x0000000000000040,
-            0x16c760661bc5ed683d27dc2f045a81a67e837928527e0de209a195b6db60f462
+            0x135fc2adb4f8569783f67b463d2245d95ea98046523a02ce015edaa292a92085
         );
         NamespaceNode[] memory sideNodes = new NamespaceNode[](3);
         sideNodes[0] = NamespaceNode(
             Constants.PARITY_SHARE_NAMESPACE_ID,
             Constants.PARITY_SHARE_NAMESPACE_ID,
-            0xf5a80844a112828c28da280019cb6e97765f81e1e003cc78a198901494db2641
+            0x22efe732017c70f7ef831b3c0b841d11fdf2230cfabf178d9560e0e4beb5adcd
         );
         sideNodes[1] = NamespaceNode(
             Constants.PARITY_SHARE_NAMESPACE_ID,
             Constants.PARITY_SHARE_NAMESPACE_ID,
-            0x61d6762ff063c2008a412246bc6bb370885c4e1a935ca28ed8699dc5c68ff28a
+            0xf11ca80de48fa801927a8061e234a29b8ab63b8239a9ea1efecf92688999602d
         );
         sideNodes[2] = NamespaceNode(
             0x0000000000000010,
             0x0000000000000040,
-            0xed6a82bfecd113f693065e3b1f271f21150b6d793917402f6c05a01feb6b3eb8
+            0x31cb53b761143d0a1b6b7f096b64c6c0543266fda00654070a2d485d0a66b281
         );
 
         uint256 key = 6;
@@ -226,23 +226,23 @@ contract NamespaceMerkleTreeTest is DSTest {
         NamespaceNode memory root = NamespaceNode(
             0x0000000000000010,
             0x0000000000000040,
-            0x16c760661bc5ed683d27dc2f045a81a67e837928527e0de209a195b6db60f462
+            0x135fc2adb4f8569783f67b463d2245d95ea98046523a02ce015edaa292a92085
         );
         NamespaceNode[] memory sideNodes = new NamespaceNode[](3);
         sideNodes[0] = NamespaceNode(
             Constants.PARITY_SHARE_NAMESPACE_ID,
             Constants.PARITY_SHARE_NAMESPACE_ID,
-            0x24ddc56b10cebbf760b3a744ad3a0e91093db34b4d22995f6de6dac918e38ae5
+            0x6d9dfdf16675fe8a327bbf048a8496686ceb1444268965477c00a73720ec743a
         );
         sideNodes[1] = NamespaceNode(
             Constants.PARITY_SHARE_NAMESPACE_ID,
             Constants.PARITY_SHARE_NAMESPACE_ID,
-            0x61d6762ff063c2008a412246bc6bb370885c4e1a935ca28ed8699dc5c68ff28a
+            0xf11ca80de48fa801927a8061e234a29b8ab63b8239a9ea1efecf92688999602d
         );
         sideNodes[2] = NamespaceNode(
             0x0000000000000010,
             0x0000000000000040,
-            0xed6a82bfecd113f693065e3b1f271f21150b6d793917402f6c05a01feb6b3eb8
+            0x31cb53b761143d0a1b6b7f096b64c6c0543266fda00654070a2d485d0a66b281
         );
 
         uint256 key = 7;

--- a/src/lib/tree/namespace/test/TreeHasher.t.sol
+++ b/src/lib/tree/namespace/test/TreeHasher.t.sol
@@ -21,7 +21,7 @@ contract TreeHasherTest is DSTest {
         NamespaceNode memory expected = NamespaceNode(
             nid,
             nid,
-            0x0a88111852095cae045340ea1f0b279944b2a756a213d9b50107d7489771e159
+            0x3e7077fd2f66d689e0cee6a7cf5b37bf2dca7c979af356d0a31cbc5c85605c7d
         );
         bytes memory data;
         NamespaceNode memory node = leafDigest(nid, data);
@@ -33,7 +33,7 @@ contract TreeHasherTest is DSTest {
         NamespaceNode memory expected = NamespaceNode(
             nid,
             nid,
-            0x2f8203f6673f9dffe69ca0b64e530656eb7445b062f69c32e2163931e637a659
+            0x7c5146e5a2fe11d16375bfebe907722d77fad468411a2704f3863e41993186bb
         );
         bytes memory data = hex"69";
         NamespaceNode memory node = leafDigest(nid, data);


### PR DESCRIPTION
According to the specs, the leaf node is computed as `node.v = h(0x00, d.namespaceID, d.rawData)` (ref: https://github.com/celestiaorg/celestia-app/blob/3206843b3548f04e035d7455a727ec527b22f9d8/specs/src/specs/data_structures.md?plain=1#L331). It was tested by manually creating the test vectors.

However, the current implementation incorrectly uses `node.v = h(0x00, d.namespaceID, d.namespaceID, d.rawData)`.

https://github.com/celestiaorg/quantum-gravity-bridge/blob/5f3d1ff3fb9070d064e00da87dc45a714d3d4875/src/lib/tree/namespace/TreeHasher.sol#L33

Fixes NMT library contract to compute the leaf node as per the specs. It was tested against the Go implementation directly with the below code.

```go
func TestProofs() {
	// the tree will use this namespace size
	nidSize := 8
	nids := [][]byte{
		namespace.ID{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10},
		namespace.ID{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x20},
		namespace.ID{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x30},
		namespace.ID{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40},
		namespace.ID{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
		namespace.ID{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
		namespace.ID{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
		namespace.ID{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
	}
	data := [][]byte{
		{0x01},
		{0x02},
		{0x03},
		{0x04},
		{0x05},
		{0x06},
		{0x07},
		{0x08},
	}
	// the leaves that will be pushed
	leaves := [][]byte{
		append(nids[0], data[0]...),
		append(nids[1], data[1]...),
		append(nids[2], data[2]...),
		append(nids[3], data[3]...),
		append(nids[4], data[4]...),
		append(nids[5], data[5]...),
		append(nids[6], data[6]...),
		append(nids[7], data[7]...),
	}
	// Init a tree with the namespace size as well as
	// the underlying hash function:
	tree := New(sha256.New(), NamespaceIDSize(nidSize))
	for _, d := range leaves {
		err := tree.Push(d)
		if err != nil {
			panic(fmt.Sprintf("unexpected error: %v", err))
		}
	}
	// compute the root
	root := tree.Root()
	fmt.Printf("Root\n0x%x 0x%x 0x%x\n\n", root[0:8], root[8:16], root[16:])

	for i := 0; i < 8; i++ {
		proof, err := tree.Prove(i)
		if err != nil {
			panic(fmt.Sprintf("unexpected error: %v", err))
		}
		isValid := proof.VerifyInclusion(sha256.New(), nids[i], [][]byte{data[i]}, root)
		if !isValid {
			t.Errorf("proof.VerifyInclusion() isValid: %v, want: true", isValid)
		}

		fmt.Printf("%d\n", i)
		for _, node := range proof.nodes {
			fmt.Printf("0x%x 0x%x 0x%x\n", node[0:8], node[8:16], node[16:])
		}
	}
}
```