### PR TITLE
Specify exact `go-ethereum` version for CI.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install Go Ethereum devtools
         working-directory: ./
         run: |
-          git clone https://github.com/ethereum/go-ethereum.git
+          git clone --depth 1 https://github.com/ethereum/go-ethereum.git
           cd go-ethereum
           make devtools
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install Go Ethereum devtools
         working-directory: ./
         run: |
-          git clone --depth 1 https://github.com/ethereum/go-ethereum.git
+          git clone --depth 1 --branch v1.12.0 https://github.com/ethereum/go-ethereum.git
           cd go-ethereum
           make devtools
 


### PR DESCRIPTION
https://github.com/celestiaorg/quantum-gravity-bridge/actions/runs/5305973794/jobs/9603277501?pr=152 uses `master`, which is unstable. Fix the version of `go-ethereum` to exactly `v1.12.0`.