### PR TITLE
chore: add a dockerfile replicating the CI environment locally

### DIFF
--- a/scripts/Dockerfile_Environment
+++ b/scripts/Dockerfile_Environment
@@ -1,0 +1,25 @@
+# this Dockerfile will contain the CI environment used to run the tests and generate the wrappers.
+# it would help not having to worry about the versions difference between the local setup and that of the CI
+# and would avoid the issues related to wrappers generation using different versions.
+# Note: this image is not build to be distributed or pushed to remote registries. Thus, it does not optimise the build layers and build stages.
+FROM ubuntu:22.04
+
+# install necessary dependencies
+RUN apt update && apt install -y git build-essential software-properties-common curl protobuf-compiler wget jq
+
+# install forge
+RUN curl -L https://foundry.paradigm.xyz | bash && . /root/.bashrc && foundryup
+
+# install solc
+RUN wget https://github.com/ethereum/solidity/releases/download/v0.8.20/solc-static-linux -O /usr/bin/solc && chmod +x /usr/bin/solc
+
+# install go
+RUN wget https://go.dev/dl/go1.20.6.linux-amd64.tar.gz && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.20.6.linux-amd64.tar.gz && echo 'PATH=$PATH:/usr/local/go/bin:/root/go/bin' >> ~/.bashrc
+
+# install abigen
+RUN git clone https://github.com/ethereum/go-ethereum.git && cd go-ethereum && PATH=$PATH:/usr/local/go/bin make devtools
+
+WORKDIR /root
+ENTRYPOINT bash
+
+# at this level, you can clone the qgb repo and build the wrappers, run the tests etc.


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

In order to avoid the issues related to replicating the CI environment locally to regenerate the wrappers, and run the tests, this PR adds a `Dockerfile` that replicates the environment in a docker image that can be used.

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
