### PR TITLE
ci: use Go 1.21.1 for tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: "=1.19.0"
+          go-version: "1.21.1"
 
       - name: Install Foundry
         uses: onbjerg/foundry-toolchain@v1


### PR DESCRIPTION
Closes https://github.com/celestiaorg/quantum-gravity-bridge/issues/180
